### PR TITLE
Allowing calling Storage constructor without a version to use the existing version

### DIFF
--- a/src/Storage.js
+++ b/src/Storage.js
@@ -38,14 +38,27 @@ class Storage<T> {
   name: string;
   version: number;
 
-  constructor(name: string, version: number) {
-    this.name = name;
-    this.version = version;
+  constructor(name: string, version?: number) {
+    if (version) {
+      const parsedVersion = parseInt(version, 10);
+      if (!parsedVersion || parsedVersion <= 0) {
+        throw new Error('version has to be a positive integer');
+      }
+      this.name = name;
+      this.version = parsedVersion;
 
-    const previousVersion = parseInt(get(name), 10) || 0;
-    if (version > previousVersion) {
-      remove(`${name}:${previousVersion}`);
-      set(name, version.toString(10));
+      const previousVersion = parseInt(get(name), 10) || 0;
+      if (parsedVersion > previousVersion) {
+        remove(`${name}:${previousVersion}`);
+        set(name, version.toString(10));
+      }
+    } else {
+      const existingVersion = parseInt(get(name), 10) || 0;
+      if (!existingVersion) {
+        throw new Error(`There is no existing storage named ${name}`);
+      }
+      this.name = name;
+      this.version = existingVersion;
     }
   }
 

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -1,5 +1,5 @@
 declare class Storage<T> {
-  constructor(name: string, version: number);
+  constructor(name: string, version?: number);
   read(): T | null;
   write(value: T): void;
   static reset(): void;

--- a/src/__tests__/Storage-test.js
+++ b/src/__tests__/Storage-test.js
@@ -137,3 +137,28 @@ it('will throw if localStorage throws', () => {
     Storage.reset();
   }).toThrow();
 });
+
+it('uses existing version when version is omitted', () => {
+  getItem.mockImplementationOnce((key) => {
+    expect(key).toBe(STORAGE_NAME);
+    return STORAGE_VERSION;
+  });
+  const storage = new Storage(STORAGE_NAME);
+  expect(storage.version).toBe(STORAGE_VERSION);
+  getItem.mockImplementationOnce((key) => {
+    expect(key).toBe(`${STORAGE_NAME}:${STORAGE_VERSION}`);
+    return JSON.stringify(TEST_OBJECT);
+  });
+  const json = storage.read();
+  expect(json).toEqual(TEST_OBJECT);
+});
+
+it('will throw if there is no existing version when version is omitted', () => {
+  getItem.mockImplementationOnce((key) => {
+    expect(key).toBe(STORAGE_NAME);
+    return undefined;
+  });
+  expect(() => {
+    new Storage(STORAGE_NAME);
+  }).toThrow();
+});

--- a/src/__tests__/Storage-test.js
+++ b/src/__tests__/Storage-test.js
@@ -162,3 +162,19 @@ it('will throw if there is no existing version when version is omitted', () => {
     new Storage(STORAGE_NAME);
   }).toThrow();
 });
+
+it('will throw if version is a negative number', () => {
+  expect(() => {
+    new Storage(STORAGE_NAME, -STORAGE_VERSION);
+  }).toThrow();
+});
+
+it('will throw if existing version is corrupted', () => {
+  getItem.mockImplementationOnce((key) => {
+    expect(key).toBe(STORAGE_NAME);
+    return '**' + STORAGE_VERSION + '**';
+  });
+  expect(() => {
+    new Storage(STORAGE_NAME, -STORAGE_VERSION);
+  }).toThrow();
+});


### PR DESCRIPTION
This should resolve #249 by providing access to existing storage with its version number.
