### PR TITLE
Switch to moduleResolution: nodenext with exports field

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,13 @@
 export default {
   testMatch: ['**/src/**/__tests__/**/*.ts'],
   testEnvironment: 'node',
+  moduleNameMapper: {
+    '^(\\.\\.?/.*)\\.js$': '$1',
+  },
   transform: {
-    '^.+.tsx?$': ['ts-jest', {}],
+    '^.+.tsx?$': [
+      'ts-jest',
+      {tsconfig: {isolatedModules: false}, diagnostics: {ignoreCodes: [151002]}},
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "type": "module",
   "main": "index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/Storage.js",
+      "types": "./lib/Storage.d.ts"
+    }
+  },
   "scripts": {
     "test": "jest",
     "build": "tsc",
@@ -62,5 +68,6 @@
     "*.json": "yarn eslint --fix",
     "*.(yml,yaml)": "yarn prettier -w",
     "*.(md,markdown)": "yarn prettier -w"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/__tests__/Storage-test.ts
+++ b/src/__tests__/Storage-test.ts
@@ -1,4 +1,4 @@
-import { Storage } from '../Storage';
+import { Storage } from '../Storage.js';
 
 const STORAGE_NAME = 'test_storage';
 const STORAGE_VERSION = 42;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,13 @@
     "outDir": "lib",
     "declaration": true,
     "lib": ["es2015", "dom"],
-    "module": "es2022",
-    "moduleResolution": "bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "types": ["jest"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "lib", "src/__tests__"]
+  "exclude": ["node_modules", "lib"]
 }


### PR DESCRIPTION
## Summary

- Switch from `moduleResolution: bundler` to `moduleResolution: nodenext` (with `module: nodenext`) for proper Node.js ESM semantics
- Add `exports` field to `package.json` (enabled by `nodenext` resolution)
- Revert `exclude` in `tsconfig.json` to `["node_modules", "lib"]` — tests are now type-checked by `tsc` too
- Add `isolatedModules: true` to `tsconfig.json` as required by `module: nodenext`
- Update test import to use `.js` extension as required by `nodenext`
- Add `moduleNameMapper` in `jest.config.js` to resolve `.js` → `.ts` for ts-jest
- Override `isolatedModules: false` and suppress warning TS151002 in ts-jest config, since ts-jest doesn't support ESM globals without `--experimental-vm-modules`

## Test plan

- [ ] `tsc` compiles cleanly
- [ ] All 12 Jest tests pass with no warnings
- [ ] CI validates across all Node.js versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)