### PR TITLE
Switch to moduleResolution: nodenext with exports field

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,9 +6,6 @@ export default {
     '^(\\.\\.?/.*)\\.js$': '$1',
   },
   transform: {
-    '^.+.tsx?$': [
-      'ts-jest',
-      {tsconfig: {isolatedModules: false}, diagnostics: {ignoreCodes: [151002]}},
-    ],
+    '^.+.tsx?$': ['ts-jest', {}],
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "isolatedModules": true,
     "types": ["jest"]
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary

- Switch from `moduleResolution: bundler` to `moduleResolution: nodenext` (with `module: nodenext`) for proper Node.js ESM package semantics
- Add `exports` field to `package.json` (enabled by `nodenext` resolution)
- Revert `exclude` in `tsconfig.json` to `["node_modules", "lib"]` — tests are now type-checked by `tsc` too
- Fix test import to use `.js` extension as required by `nodenext`
- Add `moduleNameMapper` in `jest.config.js` to resolve `.js` → `.ts` for ts-jest

## Test plan

- [ ] `tsc` compiles cleanly
- [ ] All 12 Jest tests pass with no warnings
- [ ] CI validates across all Node.js versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)